### PR TITLE
fix: focal point, multiple footer addresses, tooltip z-index, logo text visibility

### DIFF
--- a/packages/shared/components/core/image.tsx
+++ b/packages/shared/components/core/image.tsx
@@ -3,12 +3,13 @@ import type { ImageProps as NextImageProps } from "next/image";
 
 import { cn } from "@/lib/utils";
 import { urlFor } from "@/sanity/lib/image";
+import { stegaClean } from "@sanity/client/stega";
 import NextImage from "next/image";
 
 type ImageWithAsset = {
   asset?: {
     url?: string | null;
-    _ref?: string;
+    _ref?: string | null;
   } | null;
   alt?: string | null;
   crop?: {
@@ -35,30 +36,50 @@ function Image({
   sizes = "(max-width: 768px) 100vw, (max-width: 1200px) 50vw, 33vw",
   ...props
 }: Props) {
-  if ((!image?.asset?.url && !image?.asset?._ref) || !image.alt)
+  // stegaClean unwraps visual editing proxy objects so crop/hotspot are real objects
+  const cleanImage = stegaClean(image);
+
+  if ((!cleanImage?.asset?.url && !cleanImage?.asset?._ref) || !cleanImage.alt)
     return null;
 
   // urlFor automatically applies crop and hotspot when present in the image object
   // Filter out null values to match SanityImageSource type
   const imageForUrl: SanityImageSource = {
-    ...image,
-    asset: image.asset || undefined,
-    crop: image.crop || undefined,
-    hotspot: image.hotspot || undefined,
+    ...cleanImage,
+    asset: cleanImage.asset || undefined,
+    crop: cleanImage.crop || undefined,
+    hotspot: cleanImage.hotspot || undefined,
   };
 
   const imageUrl = urlFor(imageForUrl)
     .auto("format")
     .url();
 
+  // When hotspot is set but no crop is applied (user set focal point in Sanity
+  // without a manual crop), use CSS object-position to center the hotspot area.
+  // When crop IS set, the CDN already applies ?rect= — no CSS override needed.
+  const hasCrop = !!cleanImage.crop
+    && (cleanImage.crop.top !== 0
+      || cleanImage.crop.left !== 0
+      || cleanImage.crop.bottom !== 0
+      || cleanImage.crop.right !== 0);
+
+  const hotspotStyle
+    = !hasCrop && cleanImage.hotspot?.x != null && cleanImage.hotspot?.y != null
+      ? {
+          objectPosition: `${cleanImage.hotspot.x * 100}% ${cleanImage.hotspot.y * 100}%`,
+        }
+      : undefined;
+
   return (
     <div className={cn("relative w-full h-full", className)}>
       <NextImage
         src={imageUrl}
-        alt={image.alt}
+        alt={cleanImage.alt}
         fill
         quality={80}
         sizes={sizes}
+        style={hotspotStyle}
         {...props}
         className="object-cover"
       />

--- a/packages/shared/components/modules/footer.tsx
+++ b/packages/shared/components/modules/footer.tsx
@@ -39,26 +39,39 @@ export default function Footer({ footerData, footerInfoData }: { footerData: FOO
           <GridItem className="col-span-1 row-start-3 tablet:hidden">
             <div className="h-px w-full bg-dark"></div>
           </GridItem>
-          <GridItem className="space-y-24 tablet:space-y-0 tablet:flex tablet:justify-between">
-            <address className="not-italic">
-              <span>
-                {footerInfoData?.address?.streetName}
-                {" "}
-              </span>
-              <span>
-                {footerInfoData?.address?.streetNumber}
-                {", "}
-              </span>
-              <span>
-                {footerInfoData?.address?.floor}
-                {" "}
-              </span>
-              <span>
-                {footerInfoData?.address?.zipCode}
-                {" "}
-              </span>
-              <span>{footerInfoData?.address?.city}</span>
-            </address>
+          <GridItem className="space-y-24 tablet:space-y-0 tablet:flex tablet:justify-between tablet:items-end">
+            <div className="space-y-8">
+              {footerInfoData?.addresses?.map(addr => (
+                <address key={addr._key} className="not-italic">
+                  {addr?.streetName && (
+                    <span>
+                      {addr.streetName}
+                      {" "}
+                    </span>
+                  )}
+                  {addr?.streetNumber && (
+                    <span>
+                      {addr.streetNumber}
+                      {", "}
+                      foc
+                    </span>
+                  )}
+                  {addr?.floor && (
+                    <span>
+                      {addr.floor}
+                      {" "}
+                    </span>
+                  )}
+                  {addr?.zipCode && (
+                    <span>
+                      {addr.zipCode}
+                      {" "}
+                    </span>
+                  )}
+                  {addr?.city && <span>{addr.city}</span>}
+                </address>
+              ))}
+            </div>
             <div className="flex items-center gap-8">
               <Send strokeWidth={1.5} className="w-16 h-16 text-dark" />
               <p>{footerInfoData?.email}</p>

--- a/packages/shared/components/modules/navigation.tsx
+++ b/packages/shared/components/modules/navigation.tsx
@@ -161,7 +161,7 @@ export default function Navigation({ navigationData, logoData, contactButtonsDat
                       {logoData?.logo?.asset?.url && (
                         <NextImage src={logoData.logo.asset.url} alt="Logo" width={50} height={50} priority />
                       )}
-                      {navigationData?.logoText && <Paragraph as="span" colorScheme="light" className="hidden desktop:block">{navigationData.logoText}</Paragraph>}
+                      {navigationData?.logoText && <Paragraph as="span" colorScheme="light" className="block">{navigationData.logoText}</Paragraph>}
                     </NextLink>
 
                     {/* Desktop nav — inline links */}

--- a/packages/shared/components/ui/tooltip.tsx
+++ b/packages/shared/components/ui/tooltip.tsx
@@ -46,7 +46,7 @@ function TooltipContent({
         data-slot="tooltip-content"
         sideOffset={sideOffset}
         className={cn(
-          "bg-light text-dark rounded-base border-light border animate-in fade-in-0 zoom-in-95 data-[state=closed]:animate-out duration-normal ease-in-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 z-50 w-fit origin-(--radix-tooltip-content-transform-origin) rounded-md px-8 py-4 text-xs text-balance",
+          "bg-light text-dark rounded-base border-light border animate-in fade-in-0 zoom-in-95 data-[state=closed]:animate-out duration-normal ease-in-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 z-70 w-fit origin-(--radix-tooltip-content-transform-origin) rounded-md px-8 py-4 text-xs text-balance",
           className,
         )}
         {...props}

--- a/packages/shared/sanity/extract.json
+++ b/packages/shared/sanity/extract.json
@@ -4051,45 +4051,59 @@
         },
         "optional": true
       },
-      "address": {
+      "addresses": {
         "type": "objectAttribute",
         "value": {
-          "type": "object",
-          "attributes": {
-            "streetName": {
-              "type": "objectAttribute",
-              "value": {
-                "type": "string"
+          "type": "array",
+          "of": {
+            "type": "object",
+            "attributes": {
+              "streetName": {
+                "type": "objectAttribute",
+                "value": {
+                  "type": "string"
+                },
+                "optional": true
               },
-              "optional": true
+              "streetNumber": {
+                "type": "objectAttribute",
+                "value": {
+                  "type": "string"
+                },
+                "optional": true
+              },
+              "floor": {
+                "type": "objectAttribute",
+                "value": {
+                  "type": "string"
+                },
+                "optional": true
+              },
+              "zipCode": {
+                "type": "objectAttribute",
+                "value": {
+                  "type": "string"
+                },
+                "optional": true
+              },
+              "city": {
+                "type": "objectAttribute",
+                "value": {
+                  "type": "string"
+                },
+                "optional": true
+              }
             },
-            "streetNumber": {
-              "type": "objectAttribute",
-              "value": {
-                "type": "string"
-              },
-              "optional": true
-            },
-            "floor": {
-              "type": "objectAttribute",
-              "value": {
-                "type": "string"
-              },
-              "optional": true
-            },
-            "zipCode": {
-              "type": "objectAttribute",
-              "value": {
-                "type": "string"
-              },
-              "optional": true
-            },
-            "city": {
-              "type": "objectAttribute",
-              "value": {
-                "type": "string"
-              },
-              "optional": true
+            "rest": {
+              "type": "object",
+              "attributes": {
+                "_key": {
+                  "type": "objectAttribute",
+                  "value": {
+                    "type": "string"
+                  }
+                }
+              }
             }
           }
         },

--- a/packages/shared/sanity/lib/queries.ts
+++ b/packages/shared/sanity/lib/queries.ts
@@ -5,8 +5,10 @@ const IMAGE_QUERY = `{
   alt,
   crop,
   hotspot,
-  asset-> {
-    url
+  "asset": {
+    "_ref": asset._ref,
+    "_type": "reference",
+    "url": asset->.url
   }
 }`;
 
@@ -225,12 +227,13 @@ export const FOOTER_QUERY = defineQuery(`*[_type == "footer"][0]{
 export const FOOTER_INFO_QUERY = defineQuery(`*[_type == "globalSettings"][0]{
   "phone": contactInfo.phone,
   "email": contactInfo.email,
-  "address": {
-    "streetName": address.streetName,
-    "streetNumber": address.streetNumber,
-    "floor": address.floor,
-    "zipCode": address.zipCode,
-    "city": address.city
+  "addresses": addresses[]{
+    _key,
+    streetName,
+    streetNumber,
+    floor,
+    zipCode,
+    city
   },
   "copyright": copyright,
   "vatNumber": {

--- a/packages/shared/sanity/schema-types/global-settings-type.ts
+++ b/packages/shared/sanity/schema-types/global-settings-type.ts
@@ -59,37 +59,43 @@ export const globalSettingsType = defineType({
       ],
     }),
     defineField({
-      name: "address",
-      type: "object",
-      title: "Adresse",
-      description: "Dette vises i footeren.",
-      validation: Rule => Rule.required(),
-      fields: [
-        defineField({
-          name: "streetName",
-          type: "string",
-          title: "Vejnavn",
-        }),
-        defineField({
-          name: "streetNumber",
-          type: "string",
-          title: "Husnummer",
-        }),
-        defineField({
-          name: "floor",
-          type: "string",
-          title: "Etage",
-        }),
-        defineField({
-          name: "zipCode",
-          type: "string",
-          title: "Postnummer",
-        }),
-        defineField({
-          name: "city",
-          type: "string",
-          title: "By",
-        }),
+      name: "addresses",
+      type: "array",
+      title: "Adresser",
+      description: "Dette vises i footeren. Tilføj flere adresser efter behov.",
+      validation: Rule => Rule.required().min(1),
+      of: [
+        {
+          type: "object",
+          title: "Adresse",
+          fields: [
+            defineField({
+              name: "streetName",
+              type: "string",
+              title: "Vejnavn",
+            }),
+            defineField({
+              name: "streetNumber",
+              type: "string",
+              title: "Husnummer",
+            }),
+            defineField({
+              name: "floor",
+              type: "string",
+              title: "Etage",
+            }),
+            defineField({
+              name: "zipCode",
+              type: "string",
+              title: "Postnummer",
+            }),
+            defineField({
+              name: "city",
+              type: "string",
+              title: "By",
+            }),
+          ],
+        },
       ],
     }),
     defineField({

--- a/packages/shared/sanity/types.ts
+++ b/packages/shared/sanity/types.ts
@@ -678,13 +678,14 @@ export type GlobalSettings = {
     phone?: string;
     email?: string;
   };
-  address?: {
+  addresses?: Array<{
     streetName?: string;
     streetNumber?: string;
     floor?: string;
     zipCode?: string;
     city?: string;
-  };
+    _key: string;
+  }>;
   copyright?: string;
   vatNumberObject?: {
     vatNumberHeading?: string;
@@ -967,7 +968,7 @@ export type AllSanitySchemaTypes =
 export declare const internalGroqTypeReferenceTo: unique symbol;
 // Source: ../../packages/shared/sanity/lib/queries.ts
 // Variable: PAGE_QUERY
-// Query: *[_type in $pageTypes && slug.current == $slug][0]{  ...,    "seo": {    "title": seo.title,    "description": coalesce(seo.description,  ""),    "image": seo.image,    "noIndex": seo.noIndex == true  },  pageBuilder[]{  ...,  _type == "textAndImage" => {    ...,    image {  ...,  alt,  crop,  hotspot,  asset-> {    url  }}  },  _type == "homepageHero" => {    ...,    title,    description,    image {  ...,  alt,  crop,  hotspot,  asset-> {    url  }},    buttons[]{      ...,      "label": select(label == null => undefined, label),      linkType,      url,      page->{        _id,        _type,        "slug": slug.current      }    }  },  _type == "genericHero" => {    ...,    image {  ...,  alt,  crop,  hotspot,  asset-> {    url  }}  },  _type == "textAndLinkBlock" => {    ...,    description[]{      ...,        _type == "block" => {    ...,    children[]{      ...,      _type == "emailReference" => {        _type,        _key,        "email": globalSettings->.contactInfo.email      },      _type == "phoneReference" => {        _type,        _key,        "phone": globalSettings->.contactInfo.phone      }    }  }    },    link {      ...,      "url": select(url == null => undefined, url),      "page": page->{        _id,        _type,        "slug": slug.current      }    }  },  _type == "listModule" => {    ...,    image {  ...,  alt,  crop,  hotspot,  asset-> {    url  }}  },  _type == "featureList" => {    ...,    description[]{      ...,        _type == "block" => {    ...,    children[]{      ...,      _type == "emailReference" => {        _type,        _key,        "email": globalSettings->.contactInfo.email      },      _type == "phoneReference" => {        _type,        _key,        "phone": globalSettings->.contactInfo.phone      }    }  }    },    link {      ...,      "url": select(url == null => undefined, url),      "page": page->{        _id,        _type,        "slug": slug.current      }    }  },  _type == "quoteModule" => {    ...,  },  _type == "ctaBlock" => {    ...,    image {  ...,  alt,  crop,  hotspot,  asset-> {    url  }},    description[]{      ...,        _type == "block" => {    ...,    children[]{      ...,      _type == "emailReference" => {        _type,        _key,        "email": globalSettings->.contactInfo.email      },      _type == "phoneReference" => {        _type,        _key,        "phone": globalSettings->.contactInfo.phone      }    }  }    },    link {      ...,      "url": select(url == null => undefined, url),      "page": page->{        _id,        _type,        "slug": slug.current      }    }  },  _type == "contactModule" => {    ...,    contactButtonText,    description[]{      ...,        _type == "block" => {    ...,    children[]{      ...,      _type == "emailReference" => {        _type,        _key,        "email": globalSettings->.contactInfo.email      },      _type == "phoneReference" => {        _type,        _key,        "phone": globalSettings->.contactInfo.phone      }    }  }    }  },  _type == "richTextModule" => {    ...,    description[]{      ...,        _type == "block" => {    ...,    children[]{      ...,      _type == "emailReference" => {        _type,        _key,        "email": globalSettings->.contactInfo.email      },      _type == "phoneReference" => {        _type,        _key,        "phone": globalSettings->.contactInfo.phone      }    }  }    }  },  _type == "gridModule" => {    ...,    image {  ...,  alt,  crop,  hotspot,  asset-> {    url  }}  },  _type == "imageGrid" => {    ...,    image {  ...,  alt,  crop,  hotspot,  asset-> {    url  }}  },  _type == "priceListModule" => {    ...,    image {  ...,  alt,  crop,  hotspot,  asset-> {    url  }}  }}}
+// Query: *[_type in $pageTypes && slug.current == $slug][0]{  ...,    "seo": {    "title": seo.title,    "description": coalesce(seo.description,  ""),    "image": seo.image,    "noIndex": seo.noIndex == true  },  pageBuilder[]{  ...,  _type == "textAndImage" => {    ...,    image {  ...,  alt,  crop,  hotspot,  "asset": {    "_ref": asset._ref,    "_type": "reference",    "url": asset->.url  }}  },  _type == "homepageHero" => {    ...,    title,    description,    image {  ...,  alt,  crop,  hotspot,  "asset": {    "_ref": asset._ref,    "_type": "reference",    "url": asset->.url  }},    buttons[]{      ...,      "label": select(label == null => undefined, label),      linkType,      url,      page->{        _id,        _type,        "slug": slug.current      }    }  },  _type == "genericHero" => {    ...,    image {  ...,  alt,  crop,  hotspot,  "asset": {    "_ref": asset._ref,    "_type": "reference",    "url": asset->.url  }}  },  _type == "textAndLinkBlock" => {    ...,    description[]{      ...,        _type == "block" => {    ...,    children[]{      ...,      _type == "emailReference" => {        _type,        _key,        "email": globalSettings->.contactInfo.email      },      _type == "phoneReference" => {        _type,        _key,        "phone": globalSettings->.contactInfo.phone      }    }  }    },    link {      ...,      "url": select(url == null => undefined, url),      "page": page->{        _id,        _type,        "slug": slug.current      }    }  },  _type == "listModule" => {    ...,    image {  ...,  alt,  crop,  hotspot,  "asset": {    "_ref": asset._ref,    "_type": "reference",    "url": asset->.url  }}  },  _type == "featureList" => {    ...,    description[]{      ...,        _type == "block" => {    ...,    children[]{      ...,      _type == "emailReference" => {        _type,        _key,        "email": globalSettings->.contactInfo.email      },      _type == "phoneReference" => {        _type,        _key,        "phone": globalSettings->.contactInfo.phone      }    }  }    },    link {      ...,      "url": select(url == null => undefined, url),      "page": page->{        _id,        _type,        "slug": slug.current      }    }  },  _type == "quoteModule" => {    ...,  },  _type == "ctaBlock" => {    ...,    image {  ...,  alt,  crop,  hotspot,  "asset": {    "_ref": asset._ref,    "_type": "reference",    "url": asset->.url  }},    description[]{      ...,        _type == "block" => {    ...,    children[]{      ...,      _type == "emailReference" => {        _type,        _key,        "email": globalSettings->.contactInfo.email      },      _type == "phoneReference" => {        _type,        _key,        "phone": globalSettings->.contactInfo.phone      }    }  }    },    link {      ...,      "url": select(url == null => undefined, url),      "page": page->{        _id,        _type,        "slug": slug.current      }    }  },  _type == "contactModule" => {    ...,    contactButtonText,    description[]{      ...,        _type == "block" => {    ...,    children[]{      ...,      _type == "emailReference" => {        _type,        _key,        "email": globalSettings->.contactInfo.email      },      _type == "phoneReference" => {        _type,        _key,        "phone": globalSettings->.contactInfo.phone      }    }  }    }  },  _type == "richTextModule" => {    ...,    description[]{      ...,        _type == "block" => {    ...,    children[]{      ...,      _type == "emailReference" => {        _type,        _key,        "email": globalSettings->.contactInfo.email      },      _type == "phoneReference" => {        _type,        _key,        "phone": globalSettings->.contactInfo.phone      }    }  }    }  },  _type == "gridModule" => {    ...,    image {  ...,  alt,  crop,  hotspot,  "asset": {    "_ref": asset._ref,    "_type": "reference",    "url": asset->.url  }}  },  _type == "imageGrid" => {    ...,    image {  ...,  alt,  crop,  hotspot,  "asset": {    "_ref": asset._ref,    "_type": "reference",    "url": asset->.url  }}  },  _type == "priceListModule" => {    ...,    image {  ...,  alt,  crop,  hotspot,  "asset": {    "_ref": asset._ref,    "_type": "reference",    "url": asset->.url  }}  }}}
 export type PAGE_QUERYResult =
   | {
       _id: string;
@@ -1138,8 +1139,10 @@ export type PAGE_QUERYResult =
             }> | null;
             image: {
               asset: {
+                _ref: string | null;
+                _type: "reference";
                 url: string | null;
-              } | null;
+              };
               media?: unknown;
               hotspot: SanityImageHotspot | null;
               crop: SanityImageCrop | null;
@@ -1270,8 +1273,10 @@ export type PAGE_QUERYResult =
             title?: string;
             image: {
               asset: {
+                _ref: string | null;
+                _type: "reference";
                 url: string | null;
-              } | null;
+              };
               media?: unknown;
               hotspot: SanityImageHotspot | null;
               crop: SanityImageCrop | null;
@@ -1317,8 +1322,10 @@ export type PAGE_QUERYResult =
             title?: string;
             image: {
               asset: {
+                _ref: string | null;
+                _type: "reference";
                 url: string | null;
-              } | null;
+              };
               media?: unknown;
               hotspot: SanityImageHotspot | null;
               crop: SanityImageCrop | null;
@@ -1491,8 +1498,10 @@ export type PAGE_QUERYResult =
             title?: string;
             image: {
               asset: {
+                _ref: string | null;
+                _type: "reference";
                 url: string | null;
-              } | null;
+              };
               media?: unknown;
               hotspot: SanityImageHotspot | null;
               crop: SanityImageCrop | null;
@@ -1624,13 +1633,14 @@ export type PAGE_QUERYResult =
         phone?: string;
         email?: string;
       };
-      address?: {
+      addresses?: Array<{
         streetName?: string;
         streetNumber?: string;
         floor?: string;
         zipCode?: string;
         city?: string;
-      };
+        _key: string;
+      }>;
       copyright?: string;
       vatNumberObject?: {
         vatNumberHeading?: string;
@@ -1767,8 +1777,10 @@ export type PAGE_QUERYResult =
             }> | null;
             image: {
               asset: {
+                _ref: string | null;
+                _type: "reference";
                 url: string | null;
-              } | null;
+              };
               media?: unknown;
               hotspot: SanityImageHotspot | null;
               crop: SanityImageCrop | null;
@@ -1912,8 +1924,10 @@ export type PAGE_QUERYResult =
             description: string | null;
             image: {
               asset: {
+                _ref: string | null;
+                _type: "reference";
                 url: string | null;
-              } | null;
+              };
               media?: unknown;
               hotspot: SanityImageHotspot | null;
               crop: SanityImageCrop | null;
@@ -1971,8 +1985,10 @@ export type PAGE_QUERYResult =
             title?: string;
             image: {
               asset: {
+                _ref: string | null;
+                _type: "reference";
                 url: string | null;
-              } | null;
+              };
               media?: unknown;
               hotspot: SanityImageHotspot | null;
               crop: SanityImageCrop | null;
@@ -2145,8 +2161,10 @@ export type PAGE_QUERYResult =
             title?: string;
             image: {
               asset: {
+                _ref: string | null;
+                _type: "reference";
                 url: string | null;
-              } | null;
+              };
               media?: unknown;
               hotspot: SanityImageHotspot | null;
               crop: SanityImageCrop | null;
@@ -2521,13 +2539,14 @@ export type NOT_FOUND_PAGE_QUERYResult =
         phone?: string;
         email?: string;
       };
-      address?: {
+      addresses?: Array<{
         streetName?: string;
         streetNumber?: string;
         floor?: string;
         zipCode?: string;
         city?: string;
-      };
+        _key: string;
+      }>;
       copyright?: string;
       vatNumberObject?: {
         vatNumberHeading?: string;
@@ -2738,12 +2757,14 @@ export type NOT_FOUND_PAGE_QUERYResult =
     }
   | null;
 // Variable: LOGO_QUERY
-// Query: *[_type == "globalSettings"][0]{  "logo": logo {  ...,  alt,  crop,  hotspot,  asset-> {    url  }}}
+// Query: *[_type == "globalSettings"][0]{  "logo": logo {  ...,  alt,  crop,  hotspot,  "asset": {    "_ref": asset._ref,    "_type": "reference",    "url": asset->.url  }}}
 export type LOGO_QUERYResult = {
   logo: {
     asset: {
+      _ref: string | null;
+      _type: "reference";
       url: string | null;
-    } | null;
+    };
     media?: unknown;
     hotspot: SanityImageHotspot | null;
     crop: SanityImageCrop | null;
@@ -2825,17 +2846,18 @@ export type FOOTER_QUERYResult = {
   footerDisplayText: null;
 } | null;
 // Variable: FOOTER_INFO_QUERY
-// Query: *[_type == "globalSettings"][0]{  "phone": contactInfo.phone,  "email": contactInfo.email,  "address": {    "streetName": address.streetName,    "streetNumber": address.streetNumber,    "floor": address.floor,    "zipCode": address.zipCode,    "city": address.city  },  "copyright": copyright,  "vatNumber": {    "vatNumberHeading": vatNumberObject.vatNumberHeading,    "vatNumber": vatNumberObject.vatNumber  }}
+// Query: *[_type == "globalSettings"][0]{  "phone": contactInfo.phone,  "email": contactInfo.email,  "addresses": addresses[]{    _key,    streetName,    streetNumber,    floor,    zipCode,    city  },  "copyright": copyright,  "vatNumber": {    "vatNumberHeading": vatNumberObject.vatNumberHeading,    "vatNumber": vatNumberObject.vatNumber  }}
 export type FOOTER_INFO_QUERYResult = {
   phone: string | null;
   email: string | null;
-  address: {
+  addresses: Array<{
+    _key: string;
     streetName: string | null;
     streetNumber: string | null;
     floor: string | null;
     zipCode: string | null;
     city: string | null;
-  };
+  }> | null;
   copyright: string | null;
   vatNumber: {
     vatNumberHeading: string | null;
@@ -2843,7 +2865,7 @@ export type FOOTER_INFO_QUERYResult = {
   };
 } | null;
 // Variable: HOME_PAGE_QUERY
-// Query: *[_id == "homePage"][0]{    ...,      "seo": {    "title": seo.title,    "description": coalesce(seo.description,  ""),    "image": seo.image,    "noIndex": seo.noIndex == true  },    pageBuilder[]{  ...,  _type == "textAndImage" => {    ...,    image {  ...,  alt,  crop,  hotspot,  asset-> {    url  }}  },  _type == "homepageHero" => {    ...,    title,    description,    image {  ...,  alt,  crop,  hotspot,  asset-> {    url  }},    buttons[]{      ...,      "label": select(label == null => undefined, label),      linkType,      url,      page->{        _id,        _type,        "slug": slug.current      }    }  },  _type == "genericHero" => {    ...,    image {  ...,  alt,  crop,  hotspot,  asset-> {    url  }}  },  _type == "textAndLinkBlock" => {    ...,    description[]{      ...,        _type == "block" => {    ...,    children[]{      ...,      _type == "emailReference" => {        _type,        _key,        "email": globalSettings->.contactInfo.email      },      _type == "phoneReference" => {        _type,        _key,        "phone": globalSettings->.contactInfo.phone      }    }  }    },    link {      ...,      "url": select(url == null => undefined, url),      "page": page->{        _id,        _type,        "slug": slug.current      }    }  },  _type == "listModule" => {    ...,    image {  ...,  alt,  crop,  hotspot,  asset-> {    url  }}  },  _type == "featureList" => {    ...,    description[]{      ...,        _type == "block" => {    ...,    children[]{      ...,      _type == "emailReference" => {        _type,        _key,        "email": globalSettings->.contactInfo.email      },      _type == "phoneReference" => {        _type,        _key,        "phone": globalSettings->.contactInfo.phone      }    }  }    },    link {      ...,      "url": select(url == null => undefined, url),      "page": page->{        _id,        _type,        "slug": slug.current      }    }  },  _type == "quoteModule" => {    ...,  },  _type == "ctaBlock" => {    ...,    image {  ...,  alt,  crop,  hotspot,  asset-> {    url  }},    description[]{      ...,        _type == "block" => {    ...,    children[]{      ...,      _type == "emailReference" => {        _type,        _key,        "email": globalSettings->.contactInfo.email      },      _type == "phoneReference" => {        _type,        _key,        "phone": globalSettings->.contactInfo.phone      }    }  }    },    link {      ...,      "url": select(url == null => undefined, url),      "page": page->{        _id,        _type,        "slug": slug.current      }    }  },  _type == "contactModule" => {    ...,    contactButtonText,    description[]{      ...,        _type == "block" => {    ...,    children[]{      ...,      _type == "emailReference" => {        _type,        _key,        "email": globalSettings->.contactInfo.email      },      _type == "phoneReference" => {        _type,        _key,        "phone": globalSettings->.contactInfo.phone      }    }  }    }  },  _type == "richTextModule" => {    ...,    description[]{      ...,        _type == "block" => {    ...,    children[]{      ...,      _type == "emailReference" => {        _type,        _key,        "email": globalSettings->.contactInfo.email      },      _type == "phoneReference" => {        _type,        _key,        "phone": globalSettings->.contactInfo.phone      }    }  }    }  },  _type == "gridModule" => {    ...,    image {  ...,  alt,  crop,  hotspot,  asset-> {    url  }}  },  _type == "imageGrid" => {    ...,    image {  ...,  alt,  crop,  hotspot,  asset-> {    url  }}  },  _type == "priceListModule" => {    ...,    image {  ...,  alt,  crop,  hotspot,  asset-> {    url  }}  }}  }
+// Query: *[_id == "homePage"][0]{    ...,      "seo": {    "title": seo.title,    "description": coalesce(seo.description,  ""),    "image": seo.image,    "noIndex": seo.noIndex == true  },    pageBuilder[]{  ...,  _type == "textAndImage" => {    ...,    image {  ...,  alt,  crop,  hotspot,  "asset": {    "_ref": asset._ref,    "_type": "reference",    "url": asset->.url  }}  },  _type == "homepageHero" => {    ...,    title,    description,    image {  ...,  alt,  crop,  hotspot,  "asset": {    "_ref": asset._ref,    "_type": "reference",    "url": asset->.url  }},    buttons[]{      ...,      "label": select(label == null => undefined, label),      linkType,      url,      page->{        _id,        _type,        "slug": slug.current      }    }  },  _type == "genericHero" => {    ...,    image {  ...,  alt,  crop,  hotspot,  "asset": {    "_ref": asset._ref,    "_type": "reference",    "url": asset->.url  }}  },  _type == "textAndLinkBlock" => {    ...,    description[]{      ...,        _type == "block" => {    ...,    children[]{      ...,      _type == "emailReference" => {        _type,        _key,        "email": globalSettings->.contactInfo.email      },      _type == "phoneReference" => {        _type,        _key,        "phone": globalSettings->.contactInfo.phone      }    }  }    },    link {      ...,      "url": select(url == null => undefined, url),      "page": page->{        _id,        _type,        "slug": slug.current      }    }  },  _type == "listModule" => {    ...,    image {  ...,  alt,  crop,  hotspot,  "asset": {    "_ref": asset._ref,    "_type": "reference",    "url": asset->.url  }}  },  _type == "featureList" => {    ...,    description[]{      ...,        _type == "block" => {    ...,    children[]{      ...,      _type == "emailReference" => {        _type,        _key,        "email": globalSettings->.contactInfo.email      },      _type == "phoneReference" => {        _type,        _key,        "phone": globalSettings->.contactInfo.phone      }    }  }    },    link {      ...,      "url": select(url == null => undefined, url),      "page": page->{        _id,        _type,        "slug": slug.current      }    }  },  _type == "quoteModule" => {    ...,  },  _type == "ctaBlock" => {    ...,    image {  ...,  alt,  crop,  hotspot,  "asset": {    "_ref": asset._ref,    "_type": "reference",    "url": asset->.url  }},    description[]{      ...,        _type == "block" => {    ...,    children[]{      ...,      _type == "emailReference" => {        _type,        _key,        "email": globalSettings->.contactInfo.email      },      _type == "phoneReference" => {        _type,        _key,        "phone": globalSettings->.contactInfo.phone      }    }  }    },    link {      ...,      "url": select(url == null => undefined, url),      "page": page->{        _id,        _type,        "slug": slug.current      }    }  },  _type == "contactModule" => {    ...,    contactButtonText,    description[]{      ...,        _type == "block" => {    ...,    children[]{      ...,      _type == "emailReference" => {        _type,        _key,        "email": globalSettings->.contactInfo.email      },      _type == "phoneReference" => {        _type,        _key,        "phone": globalSettings->.contactInfo.phone      }    }  }    }  },  _type == "richTextModule" => {    ...,    description[]{      ...,        _type == "block" => {    ...,    children[]{      ...,      _type == "emailReference" => {        _type,        _key,        "email": globalSettings->.contactInfo.email      },      _type == "phoneReference" => {        _type,        _key,        "phone": globalSettings->.contactInfo.phone      }    }  }    }  },  _type == "gridModule" => {    ...,    image {  ...,  alt,  crop,  hotspot,  "asset": {    "_ref": asset._ref,    "_type": "reference",    "url": asset->.url  }}  },  _type == "imageGrid" => {    ...,    image {  ...,  alt,  crop,  hotspot,  "asset": {    "_ref": asset._ref,    "_type": "reference",    "url": asset->.url  }}  },  _type == "priceListModule" => {    ...,    image {  ...,  alt,  crop,  hotspot,  "asset": {    "_ref": asset._ref,    "_type": "reference",    "url": asset->.url  }}  }}  }
 export type HOME_PAGE_QUERYResult =
   | {
       _id: string;
@@ -3014,8 +3036,10 @@ export type HOME_PAGE_QUERYResult =
             }> | null;
             image: {
               asset: {
+                _ref: string | null;
+                _type: "reference";
                 url: string | null;
-              } | null;
+              };
               media?: unknown;
               hotspot: SanityImageHotspot | null;
               crop: SanityImageCrop | null;
@@ -3146,8 +3170,10 @@ export type HOME_PAGE_QUERYResult =
             title?: string;
             image: {
               asset: {
+                _ref: string | null;
+                _type: "reference";
                 url: string | null;
-              } | null;
+              };
               media?: unknown;
               hotspot: SanityImageHotspot | null;
               crop: SanityImageCrop | null;
@@ -3193,8 +3219,10 @@ export type HOME_PAGE_QUERYResult =
             title?: string;
             image: {
               asset: {
+                _ref: string | null;
+                _type: "reference";
                 url: string | null;
-              } | null;
+              };
               media?: unknown;
               hotspot: SanityImageHotspot | null;
               crop: SanityImageCrop | null;
@@ -3367,8 +3395,10 @@ export type HOME_PAGE_QUERYResult =
             title?: string;
             image: {
               asset: {
+                _ref: string | null;
+                _type: "reference";
                 url: string | null;
-              } | null;
+              };
               media?: unknown;
               hotspot: SanityImageHotspot | null;
               crop: SanityImageCrop | null;
@@ -3500,13 +3530,14 @@ export type HOME_PAGE_QUERYResult =
         phone?: string;
         email?: string;
       };
-      address?: {
+      addresses?: Array<{
         streetName?: string;
         streetNumber?: string;
         floor?: string;
         zipCode?: string;
         city?: string;
-      };
+        _key: string;
+      }>;
       copyright?: string;
       vatNumberObject?: {
         vatNumberHeading?: string;
@@ -3643,8 +3674,10 @@ export type HOME_PAGE_QUERYResult =
             }> | null;
             image: {
               asset: {
+                _ref: string | null;
+                _type: "reference";
                 url: string | null;
-              } | null;
+              };
               media?: unknown;
               hotspot: SanityImageHotspot | null;
               crop: SanityImageCrop | null;
@@ -3788,8 +3821,10 @@ export type HOME_PAGE_QUERYResult =
             description: string | null;
             image: {
               asset: {
+                _ref: string | null;
+                _type: "reference";
                 url: string | null;
-              } | null;
+              };
               media?: unknown;
               hotspot: SanityImageHotspot | null;
               crop: SanityImageCrop | null;
@@ -3847,8 +3882,10 @@ export type HOME_PAGE_QUERYResult =
             title?: string;
             image: {
               asset: {
+                _ref: string | null;
+                _type: "reference";
                 url: string | null;
-              } | null;
+              };
               media?: unknown;
               hotspot: SanityImageHotspot | null;
               crop: SanityImageCrop | null;
@@ -4021,8 +4058,10 @@ export type HOME_PAGE_QUERYResult =
             title?: string;
             image: {
               asset: {
+                _ref: string | null;
+                _type: "reference";
                 url: string | null;
-              } | null;
+              };
               media?: unknown;
               hotspot: SanityImageHotspot | null;
               crop: SanityImageCrop | null;
@@ -4291,14 +4330,14 @@ export type SITEMAP_QUERYResult = Array<{
 import "@sanity/client";
 declare module "@sanity/client" {
   interface SanityQueries {
-    '*[_type in $pageTypes && slug.current == $slug][0]{\n  ...,\n  \n  "seo": {\n    "title": seo.title,\n    "description": coalesce(seo.description,  ""),\n    "image": seo.image,\n    "noIndex": seo.noIndex == true\n  },\n\n  pageBuilder[]{\n  ...,\n  _type == "textAndImage" => {\n    ...,\n    image {\n  ...,\n  alt,\n  crop,\n  hotspot,\n  asset-> {\n    url\n  }\n}\n  }\n,\n  _type == "homepageHero" => {\n    ...,\n    title,\n    description,\n    image {\n  ...,\n  alt,\n  crop,\n  hotspot,\n  asset-> {\n    url\n  }\n},\n    buttons[]{\n      ...,\n      "label": select(label == null => undefined, label),\n      linkType,\n      url,\n      page->{\n        _id,\n        _type,\n        "slug": slug.current\n      }\n    }\n  }\n,\n  _type == "genericHero" => {\n    ...,\n    image {\n  ...,\n  alt,\n  crop,\n  hotspot,\n  asset-> {\n    url\n  }\n}\n  }\n,\n  _type == "textAndLinkBlock" => {\n    ...,\n    description[]{\n      ...,\n      \n  _type == "block" => {\n    ...,\n    children[]{\n      ...,\n      _type == "emailReference" => {\n        _type,\n        _key,\n        "email": globalSettings->.contactInfo.email\n      },\n      _type == "phoneReference" => {\n        _type,\n        _key,\n        "phone": globalSettings->.contactInfo.phone\n      }\n    }\n  }\n\n    },\n    link {\n      ...,\n      "url": select(url == null => undefined, url),\n      "page": page->{\n        _id,\n        _type,\n        "slug": slug.current\n      }\n    }\n  }\n,\n  _type == "listModule" => {\n    ...,\n    image {\n  ...,\n  alt,\n  crop,\n  hotspot,\n  asset-> {\n    url\n  }\n}\n  }\n,\n  _type == "featureList" => {\n    ...,\n    description[]{\n      ...,\n      \n  _type == "block" => {\n    ...,\n    children[]{\n      ...,\n      _type == "emailReference" => {\n        _type,\n        _key,\n        "email": globalSettings->.contactInfo.email\n      },\n      _type == "phoneReference" => {\n        _type,\n        _key,\n        "phone": globalSettings->.contactInfo.phone\n      }\n    }\n  }\n\n    },\n    link {\n      ...,\n      "url": select(url == null => undefined, url),\n      "page": page->{\n        _id,\n        _type,\n        "slug": slug.current\n      }\n    }\n  }\n,\n  _type == "quoteModule" => {\n    ...,\n  }\n,\n  _type == "ctaBlock" => {\n    ...,\n    image {\n  ...,\n  alt,\n  crop,\n  hotspot,\n  asset-> {\n    url\n  }\n},\n    description[]{\n      ...,\n      \n  _type == "block" => {\n    ...,\n    children[]{\n      ...,\n      _type == "emailReference" => {\n        _type,\n        _key,\n        "email": globalSettings->.contactInfo.email\n      },\n      _type == "phoneReference" => {\n        _type,\n        _key,\n        "phone": globalSettings->.contactInfo.phone\n      }\n    }\n  }\n\n    },\n    link {\n      ...,\n      "url": select(url == null => undefined, url),\n      "page": page->{\n        _id,\n        _type,\n        "slug": slug.current\n      }\n    }\n  }\n,\n  _type == "contactModule" => {\n    ...,\n    contactButtonText,\n    description[]{\n      ...,\n      \n  _type == "block" => {\n    ...,\n    children[]{\n      ...,\n      _type == "emailReference" => {\n        _type,\n        _key,\n        "email": globalSettings->.contactInfo.email\n      },\n      _type == "phoneReference" => {\n        _type,\n        _key,\n        "phone": globalSettings->.contactInfo.phone\n      }\n    }\n  }\n\n    }\n  }\n,\n  _type == "richTextModule" => {\n    ...,\n    description[]{\n      ...,\n      \n  _type == "block" => {\n    ...,\n    children[]{\n      ...,\n      _type == "emailReference" => {\n        _type,\n        _key,\n        "email": globalSettings->.contactInfo.email\n      },\n      _type == "phoneReference" => {\n        _type,\n        _key,\n        "phone": globalSettings->.contactInfo.phone\n      }\n    }\n  }\n\n    }\n  }\n,\n  _type == "gridModule" => {\n    ...,\n    image {\n  ...,\n  alt,\n  crop,\n  hotspot,\n  asset-> {\n    url\n  }\n}\n  }\n,\n  _type == "imageGrid" => {\n    ...,\n    image {\n  ...,\n  alt,\n  crop,\n  hotspot,\n  asset-> {\n    url\n  }\n}\n  }\n,\n  _type == "priceListModule" => {\n    ...,\n    image {\n  ...,\n  alt,\n  crop,\n  hotspot,\n  asset-> {\n    url\n  }\n}\n  }\n}\n}': PAGE_QUERYResult;
+    '*[_type in $pageTypes && slug.current == $slug][0]{\n  ...,\n  \n  "seo": {\n    "title": seo.title,\n    "description": coalesce(seo.description,  ""),\n    "image": seo.image,\n    "noIndex": seo.noIndex == true\n  },\n\n  pageBuilder[]{\n  ...,\n  _type == "textAndImage" => {\n    ...,\n    image {\n  ...,\n  alt,\n  crop,\n  hotspot,\n  "asset": {\n    "_ref": asset._ref,\n    "_type": "reference",\n    "url": asset->.url\n  }\n}\n  }\n,\n  _type == "homepageHero" => {\n    ...,\n    title,\n    description,\n    image {\n  ...,\n  alt,\n  crop,\n  hotspot,\n  "asset": {\n    "_ref": asset._ref,\n    "_type": "reference",\n    "url": asset->.url\n  }\n},\n    buttons[]{\n      ...,\n      "label": select(label == null => undefined, label),\n      linkType,\n      url,\n      page->{\n        _id,\n        _type,\n        "slug": slug.current\n      }\n    }\n  }\n,\n  _type == "genericHero" => {\n    ...,\n    image {\n  ...,\n  alt,\n  crop,\n  hotspot,\n  "asset": {\n    "_ref": asset._ref,\n    "_type": "reference",\n    "url": asset->.url\n  }\n}\n  }\n,\n  _type == "textAndLinkBlock" => {\n    ...,\n    description[]{\n      ...,\n      \n  _type == "block" => {\n    ...,\n    children[]{\n      ...,\n      _type == "emailReference" => {\n        _type,\n        _key,\n        "email": globalSettings->.contactInfo.email\n      },\n      _type == "phoneReference" => {\n        _type,\n        _key,\n        "phone": globalSettings->.contactInfo.phone\n      }\n    }\n  }\n\n    },\n    link {\n      ...,\n      "url": select(url == null => undefined, url),\n      "page": page->{\n        _id,\n        _type,\n        "slug": slug.current\n      }\n    }\n  }\n,\n  _type == "listModule" => {\n    ...,\n    image {\n  ...,\n  alt,\n  crop,\n  hotspot,\n  "asset": {\n    "_ref": asset._ref,\n    "_type": "reference",\n    "url": asset->.url\n  }\n}\n  }\n,\n  _type == "featureList" => {\n    ...,\n    description[]{\n      ...,\n      \n  _type == "block" => {\n    ...,\n    children[]{\n      ...,\n      _type == "emailReference" => {\n        _type,\n        _key,\n        "email": globalSettings->.contactInfo.email\n      },\n      _type == "phoneReference" => {\n        _type,\n        _key,\n        "phone": globalSettings->.contactInfo.phone\n      }\n    }\n  }\n\n    },\n    link {\n      ...,\n      "url": select(url == null => undefined, url),\n      "page": page->{\n        _id,\n        _type,\n        "slug": slug.current\n      }\n    }\n  }\n,\n  _type == "quoteModule" => {\n    ...,\n  }\n,\n  _type == "ctaBlock" => {\n    ...,\n    image {\n  ...,\n  alt,\n  crop,\n  hotspot,\n  "asset": {\n    "_ref": asset._ref,\n    "_type": "reference",\n    "url": asset->.url\n  }\n},\n    description[]{\n      ...,\n      \n  _type == "block" => {\n    ...,\n    children[]{\n      ...,\n      _type == "emailReference" => {\n        _type,\n        _key,\n        "email": globalSettings->.contactInfo.email\n      },\n      _type == "phoneReference" => {\n        _type,\n        _key,\n        "phone": globalSettings->.contactInfo.phone\n      }\n    }\n  }\n\n    },\n    link {\n      ...,\n      "url": select(url == null => undefined, url),\n      "page": page->{\n        _id,\n        _type,\n        "slug": slug.current\n      }\n    }\n  }\n,\n  _type == "contactModule" => {\n    ...,\n    contactButtonText,\n    description[]{\n      ...,\n      \n  _type == "block" => {\n    ...,\n    children[]{\n      ...,\n      _type == "emailReference" => {\n        _type,\n        _key,\n        "email": globalSettings->.contactInfo.email\n      },\n      _type == "phoneReference" => {\n        _type,\n        _key,\n        "phone": globalSettings->.contactInfo.phone\n      }\n    }\n  }\n\n    }\n  }\n,\n  _type == "richTextModule" => {\n    ...,\n    description[]{\n      ...,\n      \n  _type == "block" => {\n    ...,\n    children[]{\n      ...,\n      _type == "emailReference" => {\n        _type,\n        _key,\n        "email": globalSettings->.contactInfo.email\n      },\n      _type == "phoneReference" => {\n        _type,\n        _key,\n        "phone": globalSettings->.contactInfo.phone\n      }\n    }\n  }\n\n    }\n  }\n,\n  _type == "gridModule" => {\n    ...,\n    image {\n  ...,\n  alt,\n  crop,\n  hotspot,\n  "asset": {\n    "_ref": asset._ref,\n    "_type": "reference",\n    "url": asset->.url\n  }\n}\n  }\n,\n  _type == "imageGrid" => {\n    ...,\n    image {\n  ...,\n  alt,\n  crop,\n  hotspot,\n  "asset": {\n    "_ref": asset._ref,\n    "_type": "reference",\n    "url": asset->.url\n  }\n}\n  }\n,\n  _type == "priceListModule" => {\n    ...,\n    image {\n  ...,\n  alt,\n  crop,\n  hotspot,\n  "asset": {\n    "_ref": asset._ref,\n    "_type": "reference",\n    "url": asset->.url\n  }\n}\n  }\n}\n}': PAGE_QUERYResult;
     '*[_id == "notFoundPage"][0]{\n  ...,\n  \n  "seo": {\n    "title": seo.title,\n    "description": coalesce(seo.description,  ""),\n    "image": seo.image,\n    "noIndex": seo.noIndex == true\n  },\n\n  heading,\n  subheading,\n}': NOT_FOUND_PAGE_QUERYResult;
-    '*[_type == "globalSettings"][0]{\n  "logo": logo {\n  ...,\n  alt,\n  crop,\n  hotspot,\n  asset-> {\n    url\n  }\n}\n}': LOGO_QUERYResult;
+    '*[_type == "globalSettings"][0]{\n  "logo": logo {\n  ...,\n  alt,\n  crop,\n  hotspot,\n  "asset": {\n    "_ref": asset._ref,\n    "_type": "reference",\n    "url": asset->.url\n  }\n}\n}': LOGO_QUERYResult;
     '*[_type == "globalSettings"][0]{\n  "email": contactInfo.email,\n  "copyEmailTooltipText": copyEmailTooltipText\n}': CONTACT_BUTTONS_QUERYResult;
     '*[_type == "navigation"][0]{\n  ...,\n  logoText,\n  contactButtonText,\n  menu[]{\n    _type,\n    "label": select(label == null => undefined, label),\n    "linkType": select(linkType == null => undefined, linkType),\n    "url": select(url == null => undefined, url),\n    "page": page->{\n      _id,\n      _type,\n      "slug": slug.current\n    }\n  },\n}': NAVIGATION_QUERYResult;
     '*[_type == "footer"][0]{\n  ...,\n  menu[]{\n    _type,\n    "label": select(label == null => undefined, label),\n    "linkType": select(linkType == null => undefined, linkType),\n    "url": select(url == null => undefined, url),\n    "page": page->{\n      _id,\n      _type,\n      "slug": slug.current\n    }\n  },\n  footerDisplayText\n}': FOOTER_QUERYResult;
-    '*[_type == "globalSettings"][0]{\n  "phone": contactInfo.phone,\n  "email": contactInfo.email,\n  "address": {\n    "streetName": address.streetName,\n    "streetNumber": address.streetNumber,\n    "floor": address.floor,\n    "zipCode": address.zipCode,\n    "city": address.city\n  },\n  "copyright": copyright,\n  "vatNumber": {\n    "vatNumberHeading": vatNumberObject.vatNumberHeading,\n    "vatNumber": vatNumberObject.vatNumber\n  }\n}': FOOTER_INFO_QUERYResult;
-    '*[_id == "homePage"][0]{\n    ...,\n    \n  "seo": {\n    "title": seo.title,\n    "description": coalesce(seo.description,  ""),\n    "image": seo.image,\n    "noIndex": seo.noIndex == true\n  },\n\n    pageBuilder[]{\n  ...,\n  _type == "textAndImage" => {\n    ...,\n    image {\n  ...,\n  alt,\n  crop,\n  hotspot,\n  asset-> {\n    url\n  }\n}\n  }\n,\n  _type == "homepageHero" => {\n    ...,\n    title,\n    description,\n    image {\n  ...,\n  alt,\n  crop,\n  hotspot,\n  asset-> {\n    url\n  }\n},\n    buttons[]{\n      ...,\n      "label": select(label == null => undefined, label),\n      linkType,\n      url,\n      page->{\n        _id,\n        _type,\n        "slug": slug.current\n      }\n    }\n  }\n,\n  _type == "genericHero" => {\n    ...,\n    image {\n  ...,\n  alt,\n  crop,\n  hotspot,\n  asset-> {\n    url\n  }\n}\n  }\n,\n  _type == "textAndLinkBlock" => {\n    ...,\n    description[]{\n      ...,\n      \n  _type == "block" => {\n    ...,\n    children[]{\n      ...,\n      _type == "emailReference" => {\n        _type,\n        _key,\n        "email": globalSettings->.contactInfo.email\n      },\n      _type == "phoneReference" => {\n        _type,\n        _key,\n        "phone": globalSettings->.contactInfo.phone\n      }\n    }\n  }\n\n    },\n    link {\n      ...,\n      "url": select(url == null => undefined, url),\n      "page": page->{\n        _id,\n        _type,\n        "slug": slug.current\n      }\n    }\n  }\n,\n  _type == "listModule" => {\n    ...,\n    image {\n  ...,\n  alt,\n  crop,\n  hotspot,\n  asset-> {\n    url\n  }\n}\n  }\n,\n  _type == "featureList" => {\n    ...,\n    description[]{\n      ...,\n      \n  _type == "block" => {\n    ...,\n    children[]{\n      ...,\n      _type == "emailReference" => {\n        _type,\n        _key,\n        "email": globalSettings->.contactInfo.email\n      },\n      _type == "phoneReference" => {\n        _type,\n        _key,\n        "phone": globalSettings->.contactInfo.phone\n      }\n    }\n  }\n\n    },\n    link {\n      ...,\n      "url": select(url == null => undefined, url),\n      "page": page->{\n        _id,\n        _type,\n        "slug": slug.current\n      }\n    }\n  }\n,\n  _type == "quoteModule" => {\n    ...,\n  }\n,\n  _type == "ctaBlock" => {\n    ...,\n    image {\n  ...,\n  alt,\n  crop,\n  hotspot,\n  asset-> {\n    url\n  }\n},\n    description[]{\n      ...,\n      \n  _type == "block" => {\n    ...,\n    children[]{\n      ...,\n      _type == "emailReference" => {\n        _type,\n        _key,\n        "email": globalSettings->.contactInfo.email\n      },\n      _type == "phoneReference" => {\n        _type,\n        _key,\n        "phone": globalSettings->.contactInfo.phone\n      }\n    }\n  }\n\n    },\n    link {\n      ...,\n      "url": select(url == null => undefined, url),\n      "page": page->{\n        _id,\n        _type,\n        "slug": slug.current\n      }\n    }\n  }\n,\n  _type == "contactModule" => {\n    ...,\n    contactButtonText,\n    description[]{\n      ...,\n      \n  _type == "block" => {\n    ...,\n    children[]{\n      ...,\n      _type == "emailReference" => {\n        _type,\n        _key,\n        "email": globalSettings->.contactInfo.email\n      },\n      _type == "phoneReference" => {\n        _type,\n        _key,\n        "phone": globalSettings->.contactInfo.phone\n      }\n    }\n  }\n\n    }\n  }\n,\n  _type == "richTextModule" => {\n    ...,\n    description[]{\n      ...,\n      \n  _type == "block" => {\n    ...,\n    children[]{\n      ...,\n      _type == "emailReference" => {\n        _type,\n        _key,\n        "email": globalSettings->.contactInfo.email\n      },\n      _type == "phoneReference" => {\n        _type,\n        _key,\n        "phone": globalSettings->.contactInfo.phone\n      }\n    }\n  }\n\n    }\n  }\n,\n  _type == "gridModule" => {\n    ...,\n    image {\n  ...,\n  alt,\n  crop,\n  hotspot,\n  asset-> {\n    url\n  }\n}\n  }\n,\n  _type == "imageGrid" => {\n    ...,\n    image {\n  ...,\n  alt,\n  crop,\n  hotspot,\n  asset-> {\n    url\n  }\n}\n  }\n,\n  _type == "priceListModule" => {\n    ...,\n    image {\n  ...,\n  alt,\n  crop,\n  hotspot,\n  asset-> {\n    url\n  }\n}\n  }\n}\n  }': HOME_PAGE_QUERYResult;
+    '*[_type == "globalSettings"][0]{\n  "phone": contactInfo.phone,\n  "email": contactInfo.email,\n  "addresses": addresses[]{\n    _key,\n    streetName,\n    streetNumber,\n    floor,\n    zipCode,\n    city\n  },\n  "copyright": copyright,\n  "vatNumber": {\n    "vatNumberHeading": vatNumberObject.vatNumberHeading,\n    "vatNumber": vatNumberObject.vatNumber\n  }\n}': FOOTER_INFO_QUERYResult;
+    '*[_id == "homePage"][0]{\n    ...,\n    \n  "seo": {\n    "title": seo.title,\n    "description": coalesce(seo.description,  ""),\n    "image": seo.image,\n    "noIndex": seo.noIndex == true\n  },\n\n    pageBuilder[]{\n  ...,\n  _type == "textAndImage" => {\n    ...,\n    image {\n  ...,\n  alt,\n  crop,\n  hotspot,\n  "asset": {\n    "_ref": asset._ref,\n    "_type": "reference",\n    "url": asset->.url\n  }\n}\n  }\n,\n  _type == "homepageHero" => {\n    ...,\n    title,\n    description,\n    image {\n  ...,\n  alt,\n  crop,\n  hotspot,\n  "asset": {\n    "_ref": asset._ref,\n    "_type": "reference",\n    "url": asset->.url\n  }\n},\n    buttons[]{\n      ...,\n      "label": select(label == null => undefined, label),\n      linkType,\n      url,\n      page->{\n        _id,\n        _type,\n        "slug": slug.current\n      }\n    }\n  }\n,\n  _type == "genericHero" => {\n    ...,\n    image {\n  ...,\n  alt,\n  crop,\n  hotspot,\n  "asset": {\n    "_ref": asset._ref,\n    "_type": "reference",\n    "url": asset->.url\n  }\n}\n  }\n,\n  _type == "textAndLinkBlock" => {\n    ...,\n    description[]{\n      ...,\n      \n  _type == "block" => {\n    ...,\n    children[]{\n      ...,\n      _type == "emailReference" => {\n        _type,\n        _key,\n        "email": globalSettings->.contactInfo.email\n      },\n      _type == "phoneReference" => {\n        _type,\n        _key,\n        "phone": globalSettings->.contactInfo.phone\n      }\n    }\n  }\n\n    },\n    link {\n      ...,\n      "url": select(url == null => undefined, url),\n      "page": page->{\n        _id,\n        _type,\n        "slug": slug.current\n      }\n    }\n  }\n,\n  _type == "listModule" => {\n    ...,\n    image {\n  ...,\n  alt,\n  crop,\n  hotspot,\n  "asset": {\n    "_ref": asset._ref,\n    "_type": "reference",\n    "url": asset->.url\n  }\n}\n  }\n,\n  _type == "featureList" => {\n    ...,\n    description[]{\n      ...,\n      \n  _type == "block" => {\n    ...,\n    children[]{\n      ...,\n      _type == "emailReference" => {\n        _type,\n        _key,\n        "email": globalSettings->.contactInfo.email\n      },\n      _type == "phoneReference" => {\n        _type,\n        _key,\n        "phone": globalSettings->.contactInfo.phone\n      }\n    }\n  }\n\n    },\n    link {\n      ...,\n      "url": select(url == null => undefined, url),\n      "page": page->{\n        _id,\n        _type,\n        "slug": slug.current\n      }\n    }\n  }\n,\n  _type == "quoteModule" => {\n    ...,\n  }\n,\n  _type == "ctaBlock" => {\n    ...,\n    image {\n  ...,\n  alt,\n  crop,\n  hotspot,\n  "asset": {\n    "_ref": asset._ref,\n    "_type": "reference",\n    "url": asset->.url\n  }\n},\n    description[]{\n      ...,\n      \n  _type == "block" => {\n    ...,\n    children[]{\n      ...,\n      _type == "emailReference" => {\n        _type,\n        _key,\n        "email": globalSettings->.contactInfo.email\n      },\n      _type == "phoneReference" => {\n        _type,\n        _key,\n        "phone": globalSettings->.contactInfo.phone\n      }\n    }\n  }\n\n    },\n    link {\n      ...,\n      "url": select(url == null => undefined, url),\n      "page": page->{\n        _id,\n        _type,\n        "slug": slug.current\n      }\n    }\n  }\n,\n  _type == "contactModule" => {\n    ...,\n    contactButtonText,\n    description[]{\n      ...,\n      \n  _type == "block" => {\n    ...,\n    children[]{\n      ...,\n      _type == "emailReference" => {\n        _type,\n        _key,\n        "email": globalSettings->.contactInfo.email\n      },\n      _type == "phoneReference" => {\n        _type,\n        _key,\n        "phone": globalSettings->.contactInfo.phone\n      }\n    }\n  }\n\n    }\n  }\n,\n  _type == "richTextModule" => {\n    ...,\n    description[]{\n      ...,\n      \n  _type == "block" => {\n    ...,\n    children[]{\n      ...,\n      _type == "emailReference" => {\n        _type,\n        _key,\n        "email": globalSettings->.contactInfo.email\n      },\n      _type == "phoneReference" => {\n        _type,\n        _key,\n        "phone": globalSettings->.contactInfo.phone\n      }\n    }\n  }\n\n    }\n  }\n,\n  _type == "gridModule" => {\n    ...,\n    image {\n  ...,\n  alt,\n  crop,\n  hotspot,\n  "asset": {\n    "_ref": asset._ref,\n    "_type": "reference",\n    "url": asset->.url\n  }\n}\n  }\n,\n  _type == "imageGrid" => {\n    ...,\n    image {\n  ...,\n  alt,\n  crop,\n  hotspot,\n  "asset": {\n    "_ref": asset._ref,\n    "_type": "reference",\n    "url": asset->.url\n  }\n}\n  }\n,\n  _type == "priceListModule" => {\n    ...,\n    image {\n  ...,\n  alt,\n  crop,\n  hotspot,\n  "asset": {\n    "_ref": asset._ref,\n    "_type": "reference",\n    "url": asset->.url\n  }\n}\n  }\n}\n  }': HOME_PAGE_QUERYResult;
     '\n  *[_type == "redirect" && isEnabled == true] {\n      source,\n      destination,\n      permanent\n  }\n': REDIRECTS_QUERYResult;
     '\n  *[_id == $id][0]{\n    title,\n    "image": seo.image {\n      ...,\n      asset-> {\n        _id,\n        _type,\n        url,\n        metadata {\n          palette\n        }\n      }\n    }\n  }    \n': OG_IMAGE_QUERYResult;
     '\n*[_type in $pageTypes && defined(slug.current)] {\n    "href": select(\n      _type == $pageTypes[0] => "/" + slug.current,\n      slug.current\n    ),\n    _updatedAt\n}\n': SITEMAP_QUERYResult;


### PR DESCRIPTION
## Changes

### 1. Image focal point fix
- Added `stegaClean()` to unwrap Visual Editing proxy objects before passing to `urlFor()` — stega encoding prevented `@sanity/image-url` from reading crop/hotspot values
- Added `object-position` CSS from hotspot when crop is not set — CSS `object-cover` now centers on the focal point area
- Added `asset._ref` to `IMAGE_QUERY` GROQ projection for explicit CDN crop support

### 2. Multiple footer addresses
- Changed `globalSettings.address` from single object to `addresses[]` array
- Footer component maps over addresses with Sanity's `_key` as stable React key
- Updated `FOOTER_INFO_QUERY` to project array

### 3. Tooltip z-index
- Raised from `z-50` to `z-70` to render above navigation bar (`z-60`)

### 4. Logo text visibility
- Changed from `hidden desktop:block` (>=1440px) to `block` — visible on all screen sizes including mobile